### PR TITLE
Fix the missing "...\roslyn\csc.exe" file during a build process

### DIFF
--- a/Kentico.Widget.Video.Tests/Properties/AssemblyInfo.cs
+++ b/Kentico.Widget.Video.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
 [assembly: AssemblyTitle("Kentico.Widget.Video.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
@@ -15,6 +17,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("e2d994f8-cab3-49c6-9a38-83466ad2e18b")]
 
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Kentico.Widget.Video.Views/Properties/AssemblyInfo.cs
+++ b/Kentico.Widget.Video.Views/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -14,22 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("47f7a09a-c58b-4f57-86fd-7e576c6474be")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers 
-// by using the '*' as shown below:
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Kentico.Widget.Video/Properties/AssemblyInfo.cs
+++ b/Kentico.Widget.Video/Properties/AssemblyInfo.cs
@@ -1,9 +1,9 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using CMS;
 
+// Ensures that the Kentico API can discover and work with custom classes/components registered in the project
 [assembly: AssemblyDiscoverable]
 
 // General Information about an assembly is controlled through the following
@@ -18,23 +18,8 @@ using CMS;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7bc9bf35-b4c2-43ff-a932-1d29a797bf50")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SandboxSite/Properties/AssemblyInfo.cs
+++ b/SandboxSite/Properties/AssemblyInfo.cs
@@ -1,17 +1,20 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("DevelopmentSite")]
-[assembly: AssemblyDescription("")]
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SandboxSite")]
+[assembly: AssemblyDescription("The Sandbox site can be used for components testing. It is not intended to be used live.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCulture("")]
 
 [assembly: ComVisible(false)]
 [assembly: Guid("dafbd0e0-f62e-4bb6-acad-78fba75c4a3a")]
 
-[assembly: AssemblyProduct("DevelopmentSite")]
+[assembly: AssemblyProduct("SandboxSite")]
 [assembly: AssemblyCopyright("© 2019")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("12.0.0.0")]
-[assembly: AssemblyFileVersion("12.0.7104.9972")]
-[assembly: AssemblyInformationalVersion("12.0.29")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]

--- a/SandboxSite/SandboxSite.csproj
+++ b/SandboxSite/SandboxSite.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\Targets\Kentico.DotNetCompilerPlatform.Fix.targets"/>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Targets/Kentico.DotNetCompilerPlatform.Fix.targets
+++ b/Targets/Kentico.DotNetCompilerPlatform.Fix.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Fix missing RoslynToolPath property.
+       This happens only for the first build when the project is opened for the very first time and NuGet packages are restored. -->
+  <Target Name="FixMissingRoslynToolPathProperty" BeforeTargets="CopyFilesToOutputDirectory" Condition=" '$(RoslynToolPath)' == ''">
+    <PropertyGroup>
+      <RoslynToolPath>$(MSBuildThisFileDirectory)..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\tools\roslynlatest</RoslynToolPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- Re-populate the RoslynCompilerFiles after the RoslynToolPath property is set correctly -->
+      <RoslynCompilerFiles Include="$(RoslynToolPath)\*">
+        <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </RoslynCompilerFiles>      
+    </ItemGroup>
+  </Target>
+</Project>

--- a/Targets/Kentico.EmbeddedViews.targets
+++ b/Targets/Kentico.EmbeddedViews.targets
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Kentico.DotNetCompilerPlatform.Fix.targets"/>
+  <!-- Register all available Razor views in the assembly attribute and store it in a C# file -->
   <Target Name="BeforeBuild" Condition="'$(DeployOnBuild)' != 'true'">
     <ItemGroup>
       <ViewFiles Include="Views\**\*.cshtml" />
@@ -10,16 +12,24 @@
         %40"')")]
       </EmbeddedInfo>
     </PropertyGroup>
-	<MakeDir Directories="$(IntermediateOutputPath)"/>
+    <MakeDir Directories="$(IntermediateOutputPath)"/>
     <WriteLinesToFile File="$(IntermediateOutputPath)\ViewsPathsGenerated.cs" Lines="$(EmbeddedInfo)" Overwrite="true" Encoding="Utf-8" />
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)\ViewsPathsGenerated.cs" />
     </ItemGroup>
   </Target>
-  <Target Name="AfterBuild" Condition="'$(DeployOnBuild)' != 'true'">
+  <!-- Compile Razor views -->
+  <Target Name="AfterBuild" DependsOnTargets="FixMissingILRepackProperty" Condition="'$(DeployOnBuild)' != 'true'">
     <AspNetCompiler LogStandardErrorAsError="true" VirtualPath="/" PhysicalPath="$(MSBuildProjectDirectory)" TargetPath="$(IntermediateOutputPath)\Precompiled" Force="true" Debug="false" Updateable="false" Clean="true" />
     <Exec LogStandardErrorAsError="true" Command="$(ILRepack) /noRepackRes /parallel /wildcards /out:$(IntermediateOutputPath)\Precompiled\bin\$(AssemblyName).dll $(IntermediateOutputPath)\Precompiled\bin\$(AssemblyName).dll $(IntermediateOutputPath)\Precompiled\bin\App_Web_*.dll" />
     <Copy SourceFiles="$(IntermediateOutputPath)\Precompiled\bin\$(AssemblyName).dll" DestinationFolder="$(MSBuildProjectDirectory)\..\SandboxSite\bin\" />
     <Copy SourceFiles="$(IntermediateOutputPath)\Precompiled\bin\$(AssemblyName).pdb" DestinationFolder="$(MSBuildProjectDirectory)\..\SandboxSite\bin\" />
+  </Target>
+  <!-- Fix missing ILRepack property.
+       This happens only for the first build when the project is opened for the very first time and NuGet packages are restored. -->
+  <Target Name="FixMissingILRepackProperty" Condition=" '$(ILRepack)' == ''">
+    <PropertyGroup>
+      <ILRepack>$(MSBuildThisFileDirectory)..\packages\ILRepack.2.0.17\tools\ILRepack.exe</ILRepack>
+    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
### Motivation
The first build of this solution could end up with an error stating that roslyn/csc.exe file is missing in the Kentico.Widget.Video.Views/bin folder

### How to test
Check that the fist and succeeding builds are successful. Try to open/close Visual Studio 