### PR TITLE
Correct StackOverflow links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Sorry to hear that. Just log a new [GitHub issue](../../issues) and someone will
 <img align="right" width="100" height="100" src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-icon.svg">
 
 To get help with coding and structuring your projects, use [StackOverflow](https://stackoverflow.com/) to ask questions with one of the following tags:
-- [`kentico-cloud`](https://stackoverflow.com/questions/tagged/kentico-cloud)
+- [`kentico-mvc`](https://stackoverflow.com/questions/tagged/kentico-mvc)
 - [`kentico`](https://stackoverflow.com/questions/tagged/kentico)
 
 Our team members and the community monitor these channels on a regular basis.


### PR DESCRIPTION
### Motivation

CONTRIBUTING.md listed one link to StackOverflow site which was not related to this repository as it addressed Kentico Kontent, not Kentico EMS.

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Ensure that both links preceded by paragraph "To get help with coding and structuring your projects, use StackOverflow to ask questions with one of the following tags:" work and point at `kentico-mvc` and `kentico` tags.
