### PR TITLE
CM-12915 Don't take 'imageAllowedTypes' option into account when selecting media file link

### DIFF
--- a/Kentico.InlineEditor.RichText.Tests/Properties/AssemblyInfo.cs
+++ b/Kentico.InlineEditor.RichText.Tests/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a74c858c-91df-4614-9689-718cb8b9b328")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/Kentico.InlineEditor.RichText/Assets/InlineEditors/Kentico.RichText/plugins/links/link-commands.ts
+++ b/Kentico.InlineEditor.RichText/Assets/InlineEditors/Kentico.RichText/plugins/links/link-commands.ts
@@ -197,10 +197,8 @@ const getItemSelectionCommandParameters = (commandName: OpenItemSelectionCommand
 
         if (commandName === constants.OPEN_PAGE_SELECTION_DIALOG_COMMAND_NAME) {
             options.identifierMode = IdentifierMode.Guid;
-        } else {
-            options.allowedExtensions = `.${this.opts.imageAllowedTypes.join(";.")}`;
         }
-
+        
         selector.open(options);
     }
 })

--- a/Kentico.InlineEditor.RichText/Properties/AssemblyInfo.cs
+++ b/Kentico.InlineEditor.RichText/Properties/AssemblyInfo.cs
@@ -21,8 +21,8 @@ using CMS;
 [assembly: ComVisible(false)]
 [assembly: Guid("cc8499d6-4f7c-4a4c-a902-d6ff1264653c")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
 
 [assembly: InternalsVisibleTo("Kentico.InlineEditor.RichText.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Kentico.Widget.RichText.Tests/Properties/AssemblyInfo.cs
+++ b/Kentico.Widget.RichText.Tests/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("a8a926a3-a453-4ccb-b058-384f8e7a8c07")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/Kentico.Widget.RichText.Views/Properties/AssemblyInfo.cs
+++ b/Kentico.Widget.RichText.Views/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/Kentico.Widget.RichText/Properties/AssemblyInfo.cs
+++ b/Kentico.Widget.RichText/Properties/AssemblyInfo.cs
@@ -22,8 +22,8 @@ using CMS;
 [assembly: ComVisible(false)]
 [assembly: Guid("2325c81a-ca2e-4489-a001-41607db6f24a")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
 
 [assembly: InternalsVisibleTo("Kentico.Widget.RichText.Tests")]
 


### PR DESCRIPTION
### Motivation

When selecting a media file to become a target of a link in the Rich text editor, the selector shouldn't restrict file types according to `imageAllowedTypes` option and should display all files instead. 

Once merged, developer won't have to work-around it by custom configuration as mentioned here: https://github.com/Kentico/ems-mvc-components/issues/95#issuecomment-579125966